### PR TITLE
Moved styling under the scope of entryPage class

### DIFF
--- a/components/entryPages.less
+++ b/components/entryPages.less
@@ -4,21 +4,22 @@
 
 
 // this probably wants to be moved into clinical:glass-ui
-input, button, select{
-  font-size: 14px;
-  line-height: 20px;
-  font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-style: 400;
-  padding: .75rem 0;
-  line-height: 1.5rem !important;
-  border: none;
-  border-radius: 0;
-  box-sizing: border-box;
-  //color: #333333;
-  outline: none;
-  padding-left: 3em;
+.entryPage {
+   input, button, select{
+    font-size: 14px;
+    line-height: 20px;
+    font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-style: 400;
+    padding: .75rem 0;
+    line-height: 1.5rem !important;
+    border: none;
+    border-radius: 0;
+    box-sizing: border-box;
+    //color: #333333;
+    outline: none;
+    padding-left: 3em;
+  } 
 }
-
 
 .entryLogo{
   //background-color: lightgray;


### PR DESCRIPTION
Some of the entryPage styling was messing up the rest of our pages. I just put them under the scope of the entryPage class
