### PR TITLE
Cache starrynight, Meteor, and helloworld on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,7 @@
 ## Customize the test machine
 machine:
+  node:
+    version: 0.10.33
 
   # Timezone
   timezone:
@@ -25,12 +27,23 @@ checkout:
 ## Customize dependencies
 dependencies:
   cache_directories:
-    - "~/.meteor" # relative to the user's home directory
+    - ~/.meteor # relative to the user's home directory
+    - ~/nvm/v0.10.33/lib/node_modules/starrynight
+    - ~/nvm/v0.10.33/bin/starrynight
+
+  pre:
+    # Install Starrynight unless it is cached
+    - if [ ! -e ~/nvm/v0.10.33/bin/starrynight ]; then npm install -g starrynight; else echo "Starrynight seems to be cached"; fi;
+    # Install  Meteor
+    - mkdir -p ${HOME}/.meteor
+    # If Meteor is already cached, do not need to build it again.
+    - if [ ! -e ${HOME}/.meteor/meteor ]; then curl https://install.meteor.com | /bin/sh; else echo "Meteor seems to be cached"; fi;
+    # Link the meteor executable into /usr/bin
+    - sudo ln -s $HOME/.meteor/meteor /usr/bin/meteor
+    # Check if the helloworld directory already exists, if it doesn't, create the helloworld app
+    - if [ ! -e ${HOME}/helloworld ]; then meteor create --release METEOR@1.1.0.3 helloworld; else echo "helloworld app seems to be cached"; fi;
 
   override:
-    - meteor || curl https://install.meteor.com | /bin/sh
-    - npm install starrynight -g
-    - meteor create --release METEOR@1.1.0.3 helloworld
     - cd helloworld
     - cd helloworld && ls -la
     - cd helloworld && rm helloworld.*


### PR DESCRIPTION
**Review carefully before merging!**

I have updated the circle.yml file to store starrynight, Meteor, and the helloworld application in the cache to reduce build times. 

Before caching, build times were 6-7 minutes, afterwards they are around 3:10 - 3:20. A large chunk of this (1:20) is the sleep(80) command waiting for Meteor to start up (I believe?).

This uses some commands found here:
https://github.com/meteorhacks/meteord/blob/master/circle.yml
http://stackoverflow.com/questions/31766930/circleci-not-caching-my-globally-installed-node-module

I am not 100% sure this works as expected! I hope that there won't be any artifacts from previous builds left in the cache, but I haven't tested this thoroughly yet. Might be best not to merge this until we properly check it.
